### PR TITLE
Hocs 1698

### DIFF
--- a/src/test/java/uk/gov/digital/ho/hocs/document/aws/S3DocumentServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/document/aws/S3DocumentServiceTest.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -33,15 +34,23 @@ public class S3DocumentServiceTest {
     @ClassRule
     public static final S3MockRule S3_MOCK_RULE = S3MockRule.builder().withSecureConnection(false).build();
 
-    private AmazonS3 untrustedClient = S3_MOCK_RULE.createS3Client();
-    private AmazonS3 trustedClient = S3_MOCK_RULE.createS3Client();
-    private S3DocumentService service = new S3DocumentService(untrustedBucketName, trustedBucketName, trustedClient, untrustedClient, "");
-
+    private AmazonS3 untrustedClient;
+    private AmazonS3 trustedClient;
+    private S3DocumentService service;
 
     @Before
     public void setUp() throws Exception {
+        untrustedClient = S3_MOCK_RULE.createS3Client();
+        trustedClient = S3_MOCK_RULE.createS3Client();
+        service = new S3DocumentService(untrustedBucketName, trustedBucketName, trustedClient, untrustedClient, "");
         clearS3Buckets();
         uploadUntrustedFiles();
+    }
+
+    @After
+    public void takeDown() {
+        untrustedClient.shutdown();
+        trustedClient.shutdown();
     }
 
     @Test

--- a/src/test/java/uk/gov/digital/ho/hocs/document/routes/DocumentConsumerIT.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/document/routes/DocumentConsumerIT.java
@@ -38,7 +38,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest
 @RunWith(CamelSpringBootRunner.class)
 @DisableJmx
-@Ignore
 public class DocumentConsumerIT {
 
     private static boolean setUpIsDone = false;


### PR DESCRIPTION
HOCS-1698
The tests in S3DocumentService are failing as the bucket clients do not shut down after the test.
Implemented code that initiates and shuts down every client before and after each test.