### PR TITLE
Add missing schema property

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,6 +24,7 @@ spring.jpa.generate-ddl=false
 spring.jpa.hibernate.ddl-auto=none
 
 spring.flyway.locations=classpath:/db/migration
+spring.flyway.schemas=document
 spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults=false
 
 docs.queue.name=document-queue


### PR DESCRIPTION
This update adds the missing 'spring.flyway.schema' property to the application.properties file. This will now set the schema name to be the same as that in production 'document' to keep consistency. 