### PR TITLE
HOCS-3189 Updated gradle to 7.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,3 +59,4 @@ dependencies {
     testImplementation('com.adobe.testing:s3mock-junit4:2.1.8')
     testImplementation('com.adobe.testing:s3mock:2.1.8')
 }
+

--- a/build.gradle
+++ b/build.gradle
@@ -36,26 +36,26 @@ dependencies {
     implementation('org.springframework.boot:spring-boot-starter-actuator')
     implementation('org.springframework.retry:spring-retry')
 
-    compile group: 'org.apache.camel', name: 'camel-spring-boot', version: '2.24.0'
-    compile group: 'org.apache.camel', name: 'camel-jackson', version: '2.24.0'
-    compile group: 'org.apache.camel', name: 'camel-aws', version: '2.24.0'
-    compile group: 'org.apache.camel', name: 'camel-http4', version: '2.24.0'
-    compile group: 'org.apache.httpcomponents', name: 'httpmime', version: '4.5.6'
-    compile group: 'com.amazonaws', name: 'aws-java-sdk', version: '1.11.553'
-    compile group: 'org.glassfish', name: 'javax.json', version: '1.0.4'
+    implementation('org.apache.camel:camel-spring-boot:2.24.0')
+    implementation('org.apache.camel:camel-jackson:2.24.0')
+    implementation('org.apache.camel:camel-aws:2.24.0')
+    implementation('org.apache.camel:camel-http4:2.24.0')
+    implementation('org.apache.httpcomponents:httpmime:4.5.6')
+    implementation('com.amazonaws:aws-java-sdk:1.11.553')
+    implementation('org.glassfish:javax.json:1.0.4')
 
     implementation('org.flywaydb:flyway-core')
 
     runtimeOnly('org.hsqldb:hsqldb')
     runtimeOnly('org.postgresql:postgresql')
 
-    compileOnly 'org.projectlombok:lombok'
-    annotationProcessor 'org.projectlombok:lombok'
+    compileOnly('org.projectlombok:lombok')
+    annotationProcessor('org.projectlombok:lombok')
 
-    testCompile "com.github.tomakehurst:wiremock-standalone:2.18.0"
-    testCompile group: 'org.apache.camel', name: 'camel-test-spring', version: '2.24.0'
-    testCompile('org.springframework.boot:spring-boot-starter-test')
-    testCompile('org.assertj:assertj-core')
-    testCompile group: 'com.adobe.testing', name: 's3mock-junit4', version: '2.1.8'
-    testCompile group: 'com.adobe.testing', name: 's3mock', version: '2.1.8'
+    testImplementation("com.github.tomakehurst:wiremock-standalone:2.18.0")
+    testImplementation('org.apache.camel:camel-test-spring:2.24.0')
+    testImplementation('org.springframework.boot:spring-boot-starter-test')
+    testImplementation('org.assertj:assertj-core')
+    testImplementation('com.adobe.testing:s3mock-junit4:2.1.8')
+    testImplementation('com.adobe.testing:s3mock:2.1.8')
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-all.zip


### PR DESCRIPTION
Updated gradle to 7.1, moving spring boot past 2.1.5 moves us from hibernate 5.3 to 5.4 so work to understand the update requirements for that is being done under another ticket