### PR TITLE
Feature/hocs 3310 upgrade spring boot

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '2.3.0.RELEASE'
+    id 'org.springframework.boot' version '2.5.1'
     id 'java'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '2.5.1'
+    id 'org.springframework.boot' version '2.3.0.RELEASE'
     id 'java'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '2.1.5.RELEASE'
+    id 'org.springframework.boot' version '2.3.0.RELEASE'
     id 'java'
 }
 

--- a/src/main/resources/application-postgres.properties
+++ b/src/main/resources/application-postgres.properties
@@ -1,1 +1,2 @@
 spring.datasource.url=jdbc:postgresql://${db.host:localhost}:${db.port:5432}/${db.name:postgres}?currentSchema=${db.schema.name:document}&user=${db.username:root}&password=${db.password:dev}&stringtype=unspecified
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,6 +19,7 @@ management.endpoints.web.path-mapping.health=/actuator/health
 spring.jmx.enabled=false
 
 spring.datasource.url=jdbc:hsqldb:mem:hocs_data;sql.syntax_pgs=true;shutdown=false
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.jpa.show-sql=false
 spring.jpa.generate-ddl=false
 spring.jpa.hibernate.ddl-auto=none

--- a/src/test/java/uk/gov/digital/ho/hocs/document/aws/S3DocumentServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/document/aws/S3DocumentServiceTest.java
@@ -23,7 +23,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-@Ignore
 public class S3DocumentServiceTest {
     private static String untrustedBucketName = "untrusted-bucked";
     private static String trustedBucketName = "trusted-bucked";

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -19,6 +19,7 @@ management.endpoints.web.path-mapping.health=/actuator/health
 spring.jmx.enabled=false
 
 spring.datasource.url=jdbc:hsqldb:mem:hocs_data;sql.syntax_pgs=true;shutdown=false
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.jpa.show-sql=false
 spring.jpa.generate-ddl=false
 spring.jpa.hibernate.ddl-auto=none


### PR DESCRIPTION
Upgrade to springboot 2.3.0

This required changes to the db dialect.
Also reinstated some S3 tests

An attempted to go to 2.5.1 made the docker build fail on drone. 2.3.0 is enough to get past the graceful shutdown issue.