### PR TITLE
Feature/hocs 3363 upgrade to spring boot 2.5.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '2.3.0.RELEASE'
+    id 'org.springframework.boot' version '2.5.1'
     id 'java'
 }
 
@@ -60,3 +60,6 @@ dependencies {
     testImplementation('com.adobe.testing:s3mock:2.1.8')
 }
 
+jar {
+    enabled = false
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/document/HocsDocsApplication.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/document/HocsDocsApplication.java
@@ -20,7 +20,7 @@ public class HocsDocsApplication {
 
 	@PreDestroy
 	public void stop() {
-		log.info("hocs-docs stopping gracefully");
+		log.info("Stopping gracefully");
 	}
 
 }


### PR DESCRIPTION
- Upgrade to SpringBoot 2.5.1
- Remove app name from logging. 