### PR TITLE
Fix/hocs 3508 document conversion failure

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/document/HocsDocsApplication.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/document/HocsDocsApplication.java
@@ -15,6 +15,7 @@ import javax.annotation.PreDestroy;
 public class HocsDocsApplication {
 
 	public static void main(String[] args) {
+		log.info("3508");
 		SpringApplication.run(HocsDocsApplication.class, args);
 	}
 

--- a/src/main/java/uk/gov/digital/ho/hocs/document/HocsDocsApplication.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/document/HocsDocsApplication.java
@@ -15,7 +15,6 @@ import javax.annotation.PreDestroy;
 public class HocsDocsApplication {
 
 	public static void main(String[] args) {
-		log.info("3508");
 		SpringApplication.run(HocsDocsApplication.class, args);
 	}
 

--- a/src/main/java/uk/gov/digital/ho/hocs/document/HttpProcessors.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/document/HttpProcessors.java
@@ -31,5 +31,6 @@ public class HttpProcessors {
     }
 
     public static final Predicate validateHttpResponse = header(Exchange.HTTP_RESPONSE_CODE).isLessThan(300);
+    public static final Predicate badRequestResponse = header(Exchange.HTTP_RESPONSE_CODE).isEqualTo(400);
 
 }


### PR DESCRIPTION
This change handles failed document conversions by returning a failed conversion document/message to the user.

Previously failed conversions were retried multiple times. 

Also, because of the multiple retries, the user could stay on the page with the document pending, and the UI polling every 5 seconds checking the document progress.
