### PR TITLE
HOCS-4034: key cannot be empty exception

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/document/DocumentDataResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/document/DocumentDataResource.java
@@ -65,14 +65,7 @@ class DocumentDataResource {
     public ResponseEntity<ByteArrayResource> getDocumentFile(@PathVariable UUID documentUUID) {
         S3Document document = documentDataService.getDocumentFile(documentUUID);
 
-        ByteArrayResource resource = new ByteArrayResource(document.getData());
-        MediaType mediaType = MediaType.valueOf(document.getMimeType());
-
-        return ResponseEntity.ok()
-                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment;filename=" + document.getOriginalFilename())
-                .contentType(mediaType)
-                .contentLength(document.getData().length)
-                .body(resource);
+        return generateFileResponseEntity(document);
     }
 
     @GetMapping(value = "/document/{documentUUID}/pdf", produces = APPLICATION_JSON_VALUE)

--- a/src/main/java/uk/gov/digital/ho/hocs/document/DocumentDataResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/document/DocumentDataResource.java
@@ -17,7 +17,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
-import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @Slf4j
 @RestController
@@ -30,14 +30,14 @@ class DocumentDataResource {
         this.documentDataService = documentDataService;
     }
 
-    @PostMapping(value = "/document", consumes = APPLICATION_JSON_UTF8_VALUE)
+    @PostMapping(value = "/document", consumes = APPLICATION_JSON_VALUE)
     public ResponseEntity<UUID> createDocument(@RequestBody CreateDocumentRequest request) {
         String convertTo = (request.getConvertTo() != null) ? request.getConvertTo() : "PDF";
         DocumentData documentData = documentDataService.createDocument(request.getExternalReferenceUUID(),request.getName(), request.getFileLink(), request.getType(), convertTo);
         return ResponseEntity.ok(documentData.getUuid());
     }
 
-    @GetMapping(value = "/document/reference/{externalReferenceUUID}", produces = APPLICATION_JSON_UTF8_VALUE)
+    @GetMapping(value = "/document/reference/{externalReferenceUUID}", produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<GetDocumentsResponse> getDocumentsForCaseForType(@PathVariable UUID externalReferenceUUID, @RequestParam(name = "type", required = false) String type) {
         Set<DocumentData> documents = new HashSet<>();
         if(type == null) {
@@ -48,7 +48,7 @@ class DocumentDataResource {
         return ResponseEntity.ok(GetDocumentsResponse.from(documents));
     }
 
-    @GetMapping(value = "/document/{documentUUID}", produces = APPLICATION_JSON_UTF8_VALUE)
+    @GetMapping(value = "/document/{documentUUID}", produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<DocumentDto> getDocumentResourceLocation(@PathVariable UUID documentUUID) {
         DocumentData document = documentDataService.getDocumentData(documentUUID);
         return ResponseEntity.ok(DocumentDto.from(document));
@@ -60,7 +60,7 @@ class DocumentDataResource {
         return ResponseEntity.ok().build();
     }
 
-    @GetMapping(value = "/document/{documentUUID}/file", produces = APPLICATION_JSON_UTF8_VALUE)
+    @GetMapping(value = "/document/{documentUUID}/file", produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<ByteArrayResource> getDocumentFile(@PathVariable UUID documentUUID) {
         S3Document document = documentDataService.getDocumentFile(documentUUID);
 
@@ -74,7 +74,7 @@ class DocumentDataResource {
                 .body(resource);
     }
 
-    @GetMapping(value = "/document/{documentUUID}/pdf", produces = APPLICATION_JSON_UTF8_VALUE)
+    @GetMapping(value = "/document/{documentUUID}/pdf", produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<ByteArrayResource> getDocumentPdf(@PathVariable UUID documentUUID) {
         S3Document document = documentDataService.getDocumentPdf(documentUUID);
 
@@ -88,7 +88,7 @@ class DocumentDataResource {
                 .body(resource);
     }
 
-    @GetMapping(value = "/document/{documentUUID}/name", produces = APPLICATION_JSON_UTF8_VALUE)
+    @GetMapping(value = "/document/{documentUUID}/name", produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<String> getDocumentName(@PathVariable UUID documentUUID) {
         DocumentData documentData = documentDataService.getDocumentData(documentUUID);
         // 'ApplicationExceptions.EntityNotFoundException' thrown in getDocumentData if null

--- a/src/main/java/uk/gov/digital/ho/hocs/document/DocumentDataService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/document/DocumentDataService.java
@@ -86,14 +86,8 @@ public class DocumentDataService {
         log.info("Set Document to deleted: {}", documentUUID, value(EVENT, DOCUMENT_DELETED));
     }
 
-    public S3Document getDocumentFile(UUID documentUUID) {
-        DocumentData documentData = getDocumentData(documentUUID);
-        try {
-            log.debug("Getting Document File: {}", documentUUID);
-            return s3DocumentService.getFileFromTrustedS3(documentData.getFileLink());
-        } catch (IOException e) {
-            throw new ApplicationExceptions.EntityNotFoundException(e.getMessage(),DOCUMENT_NOT_FOUND);
-        }
+    public S3Document getDocumentFile(UUID documentUuid) {
+        return getDocumentFromS3(documentUuid, DocumentType.ORIGINAL);
     }
 
     public S3Document getDocumentPdf(UUID documentUuid) {

--- a/src/main/java/uk/gov/digital/ho/hocs/document/DocumentDataService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/document/DocumentDataService.java
@@ -3,6 +3,7 @@ package uk.gov.digital.ho.hocs.document;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 import uk.gov.digital.ho.hocs.document.aws.S3DocumentService;
 import uk.gov.digital.ho.hocs.document.client.auditclient.AuditClient;
 import uk.gov.digital.ho.hocs.document.client.documentclient.DocumentClient;
@@ -95,13 +96,29 @@ public class DocumentDataService {
         }
     }
 
-    public S3Document getDocumentPdf(UUID documentUUID) {
-        DocumentData documentData = getDocumentData(documentUUID);
-        try{
-            log.debug("Getting Document PDF: {}", documentUUID);
-            return s3DocumentService.getFileFromTrustedS3(documentData.getPdfLink());
+    public S3Document getDocumentPdf(UUID documentUuid) {
+        return getDocumentFromS3(documentUuid, DocumentType.PDF);
+    }
+
+    private S3Document getDocumentFromS3(UUID documentUuid, DocumentType documentType) {
+        DocumentData documentData = getDocumentData(documentUuid);
+
+        String fileLink = documentType.equals(DocumentType.PDF) ? documentData.getPdfLink() : documentData.getFileLink();
+
+        if (!StringUtils.hasText(fileLink)) {
+            return new S3Document(null, documentData.getDisplayName(), new byte[0],
+                    null, null);
+        }
+
+        try {
+            return s3DocumentService.getFileFromTrustedS3(fileLink);
         } catch (IOException e) {
             throw new ApplicationExceptions.EntityNotFoundException(e.getMessage(), DOCUMENT_NOT_FOUND);
         }
+    }
+
+    private enum DocumentType {
+        ORIGINAL,
+        PDF
     }
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/document/DocumentResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/document/DocumentResourceTest.java
@@ -5,10 +5,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import uk.gov.digital.ho.hocs.document.dto.CreateDocumentRequest;
 import uk.gov.digital.ho.hocs.document.dto.GetDocumentsResponse;
+import uk.gov.digital.ho.hocs.document.dto.camel.S3Document;
 import uk.gov.digital.ho.hocs.document.exception.ApplicationExceptions;
 import uk.gov.digital.ho.hocs.document.model.DocumentData;
 
@@ -16,6 +18,7 @@ import java.util.HashSet;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -69,6 +72,23 @@ public class DocumentResourceTest {
 
         assertThat(response).isNotNull();
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    public void shouldNotReturnMimeTypeIfDoesNotExist() {
+        S3Document s3Document = mock(S3Document.class);
+        String fileName = "TEST";
+
+        when(s3Document.getMimeType()).thenReturn(null);
+        when(s3Document.getFilename()).thenReturn(null);
+        when(s3Document.getData()).thenReturn(new byte[0]);
+        when(s3Document.getOriginalFilename()).thenReturn(fileName);
+
+        when(documentService.getDocumentPdf(uuid)).thenReturn(s3Document);
+
+        var response = documentResource.getDocumentPdf(uuid);
+
+        assertFalse(response.getHeaders().containsKey(HttpHeaders.CONTENT_TYPE));
     }
 
 

--- a/src/test/java/uk/gov/digital/ho/hocs/document/DocumentResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/document/DocumentResourceTest.java
@@ -80,7 +80,6 @@ public class DocumentResourceTest {
         String fileName = "TEST";
 
         when(s3Document.getMimeType()).thenReturn(null);
-        when(s3Document.getFilename()).thenReturn(null);
         when(s3Document.getData()).thenReturn(new byte[0]);
         when(s3Document.getOriginalFilename()).thenReturn(fileName);
 

--- a/src/test/java/uk/gov/digital/ho/hocs/document/DocumentServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/document/DocumentServiceTest.java
@@ -446,6 +446,29 @@ public class DocumentServiceTest {
     }
 
     @Test
+    public void shouldReturnEmptyDocumentIfFileLinkIsEmpty() {
+        UUID documentUuid = UUID.randomUUID();
+        String originalFileName = "TEST";
+
+        DocumentData documentData = mock(DocumentData.class);
+        when(documentData.getFileLink()).thenReturn("");
+        when(documentData.getDisplayName()).thenReturn(originalFileName);
+
+        when(documentRepository.findByUuid(documentUuid)).thenReturn(documentData);
+
+        var response = documentService.getDocumentFile(documentUuid);
+
+        assertEquals(response.getOriginalFilename(), originalFileName);
+        assertEquals(response.getData().length, 0);
+        assertNull(response.getFilename());
+        assertNull(response.getFileType());
+        assertNull(response.getMimeType());
+
+        verify(documentRepository).findByUuid(documentUuid);
+        verifyNoMoreInteractions(documentRepository);
+    }
+
+    @Test
     public void shouldReturnEmptyDocumentIfPdfLinkIsEmpty() {
         UUID documentUuid = UUID.randomUUID();
         String originalFileName = "TEST";


### PR DESCRIPTION
At present when a request comes through to retrieve a copy of a converted PDF document this causes an exception as the field contains empty. 

This causes issues in the following scenarios: 
1. templates and standard lines are not converted and thus never have a pdf_link
2. Files that fail to be converted for whatever reason will have an empty pdf_link

While we handle this gracefully on the frontend and the user isn't overly impeded, as we have a 10 time retry this is causing log pollution and alerting issues.

This change introduces a check on the pdf_link and file_link (dependant on the request) and if it is empty it will now return a S3 Document that is empty. 