### PR TITLE
Hocs-4073: Remove spring-context-indexer as it causes the build to fail.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,6 @@ dependencies {
 
     compileOnly('org.projectlombok:lombok')
     annotationProcessor('org.projectlombok:lombok')
-    annotationProcessor "org.springframework:spring-context-indexer:5.3.12"
 
     testImplementation("com.github.tomakehurst:wiremock-standalone:2.18.0")
     testImplementation('org.apache.camel:camel-test-spring:2.24.0')


### PR DESCRIPTION
spring-context-indexer is not compatible with the adobe s3-mock code - remove it for now.