### PR TITLE
📌 HOCS-4212 - Upgrade Postgres version used in the project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     implementation 'com.amazonaws:aws-java-sdk:1.12.131'
     implementation 'org.glassfish:javax.json:1.0.4'
 
-    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-core:8.1.0'
     runtimeOnly 'org.hsqldb:hsqldb'
     runtimeOnly 'org.postgresql:postgresql:42.3.1'
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,12 +1,12 @@
-version: '3.1'
+version: '3.8'
 
 services:
 
   postgres:
-    image: postgres:9.6
+    image: postgres:12-alpine
     restart: always
     ports:
-      - 5432:5432
+      - "5432:5432"
     networks:
       - hocs-network
     environment:
@@ -27,27 +27,27 @@ services:
     environment:
       - CLAMD_HOST=clamd
     ports:
-      - 8086:8080
+      - "8086:8080"
     networks:
       - hocs-network
     depends_on:
       - clamd
 
-localstack:
-  image: localstack/localstack:latest
-  ports:
-    - 9000:8080
-    - 4572:4572
-    - 4576:4576
-    - 4575:4575
-    - 4571:4571
-    - 4578:4578
-  networks:
-    - hocs-network
-  environment:
-    HOSTNAME_EXTERNAL: localstack
-    DEFAULT_REGION: eu-west-2
-    SERVICES: sqs,s3,sns
+  localstack:
+    image: localstack/localstack:0.11.1
+    ports:
+      - "9000:8080"
+      - "4572:4572"
+      - "4576:4576"
+      - "4575:4575"
+      - "4571:4571"
+      - "4578:4578"
+    networks:
+      - hocs-network
+    environment:
+      HOSTNAME_EXTERNAL: localstack
+      DEFAULT_REGION: eu-west-2
+      SERVICES: sqs,s3,sns
 
   aws_cli:
     image: xueshanf/awscli
@@ -79,3 +79,6 @@ localstack:
       - hocs-network
     depends_on:
       - localstack
+
+networks:
+  hocs-network:


### PR DESCRIPTION
At the moment we are using unknown versions of Postgres in the build, this commit moves docker-compose over to using the official images. 

At the moment this project doesn't use Postgres in Drone or for integration tests and this PR does not address this.