### PR TITLE
HOCS-4682: add original file existence indicator 

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/document/dto/DocumentDto.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/document/dto/DocumentDto.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.StringUtils;
 import uk.gov.digital.ho.hocs.document.model.DocumentData;
 import uk.gov.digital.ho.hocs.document.model.DocumentStatus;
 
@@ -45,8 +46,10 @@ public class DocumentDto {
     @JsonProperty("hasPdf")
     private Boolean hasPdf;
 
-    public static DocumentDto from(DocumentData documentData) {
+    @JsonProperty("hasOriginalFile")
+    private Boolean hasOriginalFile;
 
+    public static DocumentDto from(DocumentData documentData) {
         return new DocumentDto(
                 documentData.getUuid(),
                 documentData.getExternalReferenceUUID(),
@@ -57,7 +60,8 @@ public class DocumentDto {
                 documentData.getCreated(),
                 documentData.getUpdated(),
                 documentData.getDeleted(),
-                documentData.getPdfLink() != null && !documentData.getPdfLink().isEmpty()
+                StringUtils.hasText(documentData.getPdfLink()),
+                StringUtils.hasText(documentData.getFileLink())
         );
     }
 }


### PR DESCRIPTION
Add a boolean to the DocumentDto that indicates if a file link exists
within the database response.

When a request to retrieve a document currently has an empty string for
the file link (whether original or PDF) a FileLinkMissing 404 Exception
is thrown. This changes the previous behaviour where an empty file was
returned.