### PR TITLE
HOCS-4808: support tagging on support branches

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -127,6 +127,7 @@ trigger:
     - tag
   branch:
     - main
+    - support/*
 
 steps:
   - name: test project
@@ -134,7 +135,7 @@ steps:
     commands:
       - ./gradlew clean build --no-daemon
 
-  - name: build & push
+  - name: build & push tag main
     image: plugins/docker
     settings:
       registry: quay.io
@@ -149,6 +150,27 @@ steps:
       DOCKER_USERNAME: ukhomeofficedigital+hocs_quay_robot
     depends_on:
       - test project
+    when:
+      branch:
+        - main
+
+  - name: build & push tag
+    image: plugins/docker
+    settings:
+      registry: quay.io
+      repo: quay.io/ukhomeofficedigital/hocs-docs
+      tags:
+        - ${DRONE_TAG}
+        - ${DRONE_COMMIT_SHA}
+    environment:
+      DOCKER_PASSWORD:
+        from_secret: QUAY_ROBOT_TOKEN
+      DOCKER_USERNAME: ukhomeofficedigital+hocs_quay_robot
+    depends_on:
+      - test project
+    when:
+      branch:
+        - support/*
 
 ---
 kind: pipeline


### PR DESCRIPTION
To support hotfixing this change allows the for a build and tag step to
be run on support branches aswell.