### PR TITLE
Use Async internal queues

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/document/routes/MalwareCheckConsumer.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/document/routes/MalwareCheckConsumer.java
@@ -31,6 +31,8 @@ public class MalwareCheckConsumer extends RouteBuilder {
 
     private S3DocumentService s3BucketService;
 
+    private String malwareQueue;
+
     private DocumentDataService documentDataService;
 
     private final String toQueue;
@@ -42,10 +44,12 @@ public class MalwareCheckConsumer extends RouteBuilder {
     public MalwareCheckConsumer(S3DocumentService s3BucketService,
                                 @Value("${clamav.path}") String clamAvPath,
                                 @Value("${conversionQueueName}") String toQueue,
+                                @Value("${malwareQueueName}") String malwareQueue,
                                DocumentDataService documentDataService) {
         this.s3BucketService = s3BucketService;
         this.clamAvPath = String.format("%s?throwExceptionOnFailure=false&useSystemProperties=true", clamAvPath);
         this.toQueue = toQueue;
+        this.malwareQueue = malwareQueue;
         this.documentDataService = documentDataService;
     }
 
@@ -63,7 +67,7 @@ public class MalwareCheckConsumer extends RouteBuilder {
             });
 
 
-        from("direct:malwarecheck").routeId("malware-queue")
+        from(malwareQueue).routeId("malware-queue")
                 .process(transferHeadersToMDC())
                 .log(LoggingLevel.DEBUG, "Retrieving document from S3")
                 .setProperty("uuid", simple("${body.documentUUID}"))

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,4 +1,4 @@
-docs.queue=aws-sqs://${docs.queue.name}?amazonSQSClient=#sqsClient
+docs.queue=aws-sqs://${docs.queue.name}?amazonSQSClient=#sqsClient&concurrentConsumers=${docs.concurrentConsumers:5}
 
 docs.trustedS3bucketKMSKeyId=
 

--- a/src/main/resources/application-sqs.properties
+++ b/src/main/resources/application-sqs.properties
@@ -1,1 +1,1 @@
-docs.queue=aws-sqs://arn:aws:sqs:${aws.sqs.region}:${aws.account.id}:${docs.queue.name}?amazonSQSClient=#sqsClient
+docs.queue=aws-sqs://arn:aws:sqs:${aws.sqs.region}:${aws.account.id}:${docs.queue.name}?amazonSQSClient=#sqsClient&concurrentConsumers=${docs.concurrentConsumers:5}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,9 +25,10 @@ spring.flyway.schemas=document
 spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults=false
 
 docs.queue.name=document-queue
-docs.queue=aws-sqs://arn:aws:sqs:eu-west-2:000000000000:${docs.queue.name}?amazonSQSClient=#sqsClient
-conversionQueueName=direct:convertdocument
-malwareQueueName=direct:malwarecheck
+docs.queue=aws-sqs://arn:aws:sqs:eu-west-2:000000000000:${docs.queue.name}?amazonSQSClient=#sqsClient&concurrentConsumers=3
+docs.concurrentConsumers=5
+conversionQueueName=seda:convertdocument
+malwareQueueName=seda:malwarecheck
 
 docs.untrustedS3bucketName=untrusted-bucket
 docs.untrustedS3bucket=${docs.untrustedS3bucketName}

--- a/src/test/java/uk/gov/digital/ho/hocs/document/routes/DocumentConversionConsumerTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/document/routes/DocumentConversionConsumerTest.java
@@ -50,7 +50,7 @@ public class DocumentConversionConsumerTest extends CamelTestSupport {
 
     @Override
     protected RouteBuilder createRouteBuilder() throws Exception {
-        return new DocumentConversionConsumer(s3BucketService, documentDataService, conversionService);
+        return new DocumentConversionConsumer(s3BucketService, documentDataService, conversionService, endpoint);
     }
 
     @Test

--- a/src/test/java/uk/gov/digital/ho/hocs/document/routes/DocumentMalwareCheckConsumerTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/document/routes/DocumentMalwareCheckConsumerTest.java
@@ -48,7 +48,7 @@ public class DocumentMalwareCheckConsumerTest extends CamelTestSupport {
 
     @Override
     protected RouteBuilder createRouteBuilder() {
-        return new MalwareCheckConsumer(s3BucketService, calmAVService, toEndpoint, documentDataService);
+        return new MalwareCheckConsumer(s3BucketService, calmAVService, toEndpoint, endpoint, documentDataService);
     }
 
     @Test

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -20,9 +20,8 @@ spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults=false
 docs.queue.name=document-queue
 docs.queue=seda://${docs.queue.name}
 
-conversionQueueName=direct:convertdocument
-malwareQueueName=direct:malwarecheck
-documentServiceQueueName=direct:updaterecord
+conversionQueueName=seda:convertdocument
+malwareQueueName=seda:malwarecheck
 
 docs.untrustedS3bucketName=untrusted-bucket
 docs.untrustedS3bucket=${docs.untrustedS3bucketName}


### PR DESCRIPTION
Use async Camel Seda queues for malware and conversion internal queues and allow concurrent consumption of messages from the SQS queue