### PR TITLE
Set file link to trusted file after malware scan succeeds and file is copied to trusted bucket

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/document/routes/DocumentConversionConsumer.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/document/routes/DocumentConversionConsumer.java
@@ -72,7 +72,7 @@ public class DocumentConversionConsumer extends RouteBuilder {
 
         errorHandler(deadLetterChannel("log:conversion-queue"));
 
-        onException(ApplicationExceptions.DocumentConversionException.class, ApplicationExceptions.S3Exception.class)
+        onException()
             .removeHeader(SqsConstants.RECEIPT_HANDLE)
             .process(transferHeadersToMDC())
             .handled(true).process(exchange -> {

--- a/src/main/java/uk/gov/digital/ho/hocs/document/routes/MalwareCheckConsumer.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/document/routes/MalwareCheckConsumer.java
@@ -101,12 +101,14 @@ public class MalwareCheckConsumer extends RouteBuilder {
                 .when(validMalwareResponse)
                     .process(generateDocumentCopyRequest())
                     .bean(s3BucketService, "copyToTrustedBucket")
+                    .setProperty("filelink", simple("${body.filename}"))
                     .process(generateDocumentConversionRequest())
                     .process(transferMDCToHeaders())
                     .setHeader(SqsConstants.RECEIPT_HANDLE, exchangeProperty(SqsConstants.RECEIPT_HANDLE))
                     .process(exchange -> {
+                        String filename = exchange.getProperty("filelink", String.class);
                         UUID uuid = UUID.fromString(exchange.getProperty("uuid", String.class));
-                        documentDataService.updateDocument(uuid, DocumentStatus.AWAITING_CONVERSION);
+                        documentDataService.updateDocument(uuid, DocumentStatus.AWAITING_CONVERSION, filename, null);
                     })
                     .to(toQueue)
                     .endChoice()

--- a/src/test/java/uk/gov/digital/ho/hocs/document/routes/DocumentMalwareCheckConsumerTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/document/routes/DocumentMalwareCheckConsumerTest.java
@@ -88,6 +88,7 @@ public class DocumentMalwareCheckConsumerTest extends CamelTestSupport {
         mockEndpoint.assertIsSatisfied();
     }
 
+
     @Test
     public void shouldAddDocumentToConversionQueueOnSuccess() throws Exception {
         S3Document document = getTestDocument();
@@ -105,9 +106,9 @@ public class DocumentMalwareCheckConsumerTest extends CamelTestSupport {
     @Test
     public void shouldUpdateStatusToAwaitingConversionOnSuccess() throws Exception {
         S3Document document = getTestDocument();
+        S3Document copiedDocument = getCopiedS3Document();
         when(s3BucketService.getFileFromUntrustedS3(any())).thenReturn(document);
-        when(s3BucketService.copyToTrustedBucket(any())).thenReturn(getCopiedS3Document());
-        doNothing().when(documentDataService).updateDocument(any(), eq(DocumentStatus.AWAITING_CONVERSION));
+        when(s3BucketService.copyToTrustedBucket(any())).thenReturn(copiedDocument);
 
         MockEndpoint mockMalwareService = mockMalwareService();
         getMockEndpoint(toEndpoint).expectedMessageCount(1);
@@ -116,7 +117,7 @@ public class DocumentMalwareCheckConsumerTest extends CamelTestSupport {
 
         getMockEndpoint(toEndpoint).assertIsSatisfied();
         mockMalwareService.assertIsSatisfied();
-        verify(documentDataService, times(1)).updateDocument(any(), eq(DocumentStatus.AWAITING_CONVERSION));
+        verify(documentDataService, times(1)).updateDocument(any(), eq(DocumentStatus.AWAITING_CONVERSION), eq(copiedDocument.getFilename()), eq(null));
     }
 
     @Test


### PR DESCRIPTION
Adds the filelink to the Document Data when setting the status to AWAITING MALWARE. This prevents an edge case bug where the processing fails after the document is copied to the trusted bucket but before the conversion is completed