### PR TITLE
Retry document conversion failures

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/document/DocumentDataResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/document/DocumentDataResource.java
@@ -79,6 +79,12 @@ class DocumentDataResource {
         return generateFileResponseEntity(document);
     }
 
+    @PostMapping(value = "/documents/retry/convert")
+    public ResponseEntity<Void> retryFailedDocumentConversions() {
+        documentDataService.retryFailedDocumentConversions();
+        return ResponseEntity.ok(null);
+    }
+
     private static ResponseEntity<ByteArrayResource> generateFileResponseEntity(S3Document document) {
         ByteArrayResource resource = new ByteArrayResource(document.getData());
 

--- a/src/main/java/uk/gov/digital/ho/hocs/document/dto/camel/S3DocumentMetaData.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/document/dto/camel/S3DocumentMetaData.java
@@ -1,0 +1,19 @@
+package uk.gov.digital.ho.hocs.document.dto.camel;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@SuppressWarnings("squid:S1068")
+@AllArgsConstructor
+@Getter
+public class S3DocumentMetaData {
+
+    private final String filename;
+
+    private final String originalFilename;
+
+    private final String fileType;
+
+    private final String mimeType;
+
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/document/repository/DocumentRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/document/repository/DocumentRepository.java
@@ -4,7 +4,9 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 import uk.gov.digital.ho.hocs.document.model.DocumentData;
+import uk.gov.digital.ho.hocs.document.model.DocumentStatus;
 
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
@@ -20,4 +22,6 @@ public interface DocumentRepository extends CrudRepository<DocumentData, String>
     @Query(value = "SELECT * FROM document_data WHERE external_reference_uuid = ?1 AND NOT deleted", nativeQuery = true)
     Set<DocumentData> findAllActiveByExternalReferenceUUID(UUID externalReferenceUUID);
 
+    @Query(value = "SELECT * FROM document_data WHERE status = ?1 AND NOT deleted AND file_link IS NOT NULL", nativeQuery = true)
+    List<DocumentData> findAllByStatus(String status);
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/document/DocumentServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/document/DocumentServiceTest.java
@@ -425,17 +425,6 @@ public class DocumentServiceTest {
 
     }
 
-    @Test(expected = ApplicationExceptions.EntityNotFoundException.class)
-    public void shouldNotAuditWhenUpdateDocumentFails() {
-
-        UUID uuid = UUID.randomUUID();
-        when(documentRepository.findByUuid(uuid)).thenReturn(null);
-
-        documentService.updateDocument(uuid, DocumentStatus.UPLOADED, "", "");
-
-        verifyNoInteractions(auditClient);
-    }
-
     @Test(expected = NullPointerException.class)
     public void shouldNotAuditWhenDeleteDocumentFails() {
 

--- a/src/test/java/uk/gov/digital/ho/hocs/document/aws/S3DocumentServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/document/aws/S3DocumentServiceTest.java
@@ -16,6 +16,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.digital.ho.hocs.document.application.LogEvent;
 import uk.gov.digital.ho.hocs.document.dto.camel.DocumentCopyRequest;
 import uk.gov.digital.ho.hocs.document.dto.camel.S3Document;
+import uk.gov.digital.ho.hocs.document.dto.camel.S3DocumentMetaData;
 import uk.gov.digital.ho.hocs.document.dto.camel.UploadDocument;
 import uk.gov.digital.ho.hocs.document.exception.ApplicationExceptions;
 
@@ -104,6 +105,18 @@ public class S3DocumentServiceTest {
         DocumentCopyRequest copyRequest = new DocumentCopyRequest("someUUID.docx", "someCase", "docx", "PDF");
         S3Document document = service.copyToTrustedBucket(copyRequest);
         assertThat(trustedClient.doesObjectExist(trustedBucketName, document.getFilename())).isTrue();
+    }
+
+    @Test
+    public void shouldReturnMetaDataFromTrustedBucket() throws IOException {
+        DocumentCopyRequest copyRequest = new DocumentCopyRequest("someUUID.docx", "someCase", "docx", "PDF");
+        service.copyToTrustedBucket(copyRequest);
+
+        String objectKey = trustedClient.listObjectsV2(trustedBucketName).getObjectSummaries().get(0).getKey();
+        S3DocumentMetaData metaData = service.getMetaDataFromTrustedS3(objectKey);
+        assertThat(metaData.getOriginalFilename()).isEqualTo("sample.docx");
+        assertThat(metaData.getFilename()).isEqualTo(objectKey);
+        assertThat(metaData.getFileType()).isEqualTo("docx");
     }
 
     @Test


### PR DESCRIPTION
This change creates a new endpoint to allow documents which have a status of DOCUMENT_CONVERSION_FAILURE to be retried. It does this by getting the data required to replay the message on the internal conversion queue from S3 and the document_data table. It then replays each message over the conversion queue.