### PR TITLE
Double quote content disposition filename

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/document/DocumentDataResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/document/DocumentDataResource.java
@@ -83,7 +83,7 @@ class DocumentDataResource {
         ByteArrayResource resource = new ByteArrayResource(document.getData());
 
         var response = ResponseEntity.ok().header(HttpHeaders.CONTENT_DISPOSITION,
-            "attachment;filename=" + document.getOriginalFilename());
+            "attachment;filename=\"%s\"".formatted(document.getOriginalFilename()));
 
         if (StringUtils.hasText(document.getMimeType())) {
             MediaType mediaType = MediaType.valueOf(document.getMimeType());


### PR DESCRIPTION
Presently if a originalFilename contains an unescaped comma, this causes the response to believe there is multiple files being downloaded which is not supported. This results in a `ERR_RESPONSE_HEADERS_MULTIPLE_CONTENT_DISPOSITION` error being returned. Escaping this solves this and treats the download as a singular file.